### PR TITLE
ADD: ADD message(startupmode, gtids) to be sented with notification

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ExternalSystemListener.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ExternalSystemListener.java
@@ -34,7 +34,7 @@ public interface ExternalSystemListener extends Serializable {
     void init(Properties properties);
 
     /** Send the given event to the external system. */
-    void send(AssignerStatus assignerStatus);
+    void send(AssignerStatus assignerStatus, ListenerMessageInformation listenerMessageInformation);
 
     /** Close the listener. */
     void close();

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerMessageInformation.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerMessageInformation.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mysql.source.listener;
+
+/** The information that will be sent with the notification. */
+public class ListenerMessageInformation {
+    private final String startupMode;
+    private final String gtids;
+
+    public ListenerMessageInformation(String startupMode, String gtids) {
+        this.startupMode = startupMode;
+        this.gtids = gtids;
+    }
+}

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerService.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerService.java
@@ -80,7 +80,9 @@ public class ListenerService implements Serializable {
     }
 
     /** notify all external system listeners. */
-    public void notifyAllListeners(final AssignerStatus assignerStatus) {
+    public void notifyAllListeners(
+            final AssignerStatus assignerStatus,
+            ListenerMessageInformation listenerMessageInformation) {
         if (externalSystemListeners.isEmpty() || executorService == null) {
             return;
         }
@@ -91,7 +93,8 @@ public class ListenerService implements Serializable {
                     externalSystemListeners.forEach(
                             externalSystemListener -> {
                                 try {
-                                    externalSystemListener.send(assignerStatus);
+                                    externalSystemListener.send(
+                                            assignerStatus, listenerMessageInformation);
                                 } catch (Exception e) {
                                     LOG.warn(
                                             "failed to send notification to {}",

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerServiceTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerServiceTest.java
@@ -17,6 +17,7 @@
 package com.ververica.cdc.connectors.mysql.source.listener;
 
 import com.ververica.cdc.connectors.mysql.source.assigners.AssignerStatus;
+import com.ververica.cdc.connectors.mysql.table.StartupMode;
 import org.junit.Test;
 
 import java.util.Properties;
@@ -32,7 +33,11 @@ public class ListenerServiceTest {
         listenerProperties.setProperty(
                 "listener.class", ExternalSystemListenerImplTest.class.getName());
         ListenerService listenerService = new ListenerService(listenerProperties);
-        listenerService.notifyAllListeners(AssignerStatus.INITIAL_ASSIGNING_FINISHED);
+        ListenerMessageInformation listenerMessageInformation =
+                new ListenerMessageInformation(
+                        StartupMode.SPECIFIC_OFFSETS.toString(), "UUID:1-100");
+        listenerService.notifyAllListeners(
+                AssignerStatus.INITIAL_ASSIGNING_FINISHED, listenerMessageInformation);
         /* wait for async execution */
         Thread.sleep(200);
         listenerService.close();
@@ -44,6 +49,7 @@ public class ListenerServiceTest {
     static class ExternalSystemListenerImplTest implements ExternalSystemListener {
 
         public static AssignerStatus assignerStatus;
+        public static ListenerMessageInformation listenerMessageInformation;
 
         @Override
         public String name() {
@@ -56,8 +62,11 @@ public class ListenerServiceTest {
         }
 
         @Override
-        public void send(AssignerStatus assignerStatus) {
+        public void send(
+                AssignerStatus assignerStatus,
+                ListenerMessageInformation listenerMessageInformation) {
             ExternalSystemListenerImplTest.assignerStatus = assignerStatus;
+            ExternalSystemListenerImplTest.listenerMessageInformation = listenerMessageInformation;
         }
 
         @Override


### PR DESCRIPTION
Added message information to send with notification.

Our team has implemented the message to look like the one below, but it's more useful than I thought it would be, so it would be great if you could add the `startupMode` and `gtids` information to your feature! 😄


Below are examples of messages we actually receive in flink cdc!
- case 1: start with `LATEST_OFFSET`
```
[BINLOG STREAM START]
Database: XXXX
Table: XXXXX
GTIDs: LATEST_OFFSET
```

- case 2: end `SNAPSHOT` phase
```
[SNAPSHOT FINISHED]
Database: XXXX
Table: XXXXX

[BINLOG STREAM START]
Database: XXXX
Table: XXXXX
GTIDs: 3bda59bb-2fc8-11eb-855f-fa163e2550e3:1-128377129,3c3a6a1b-c931-11ed-b0db-b4055dec129e:1-273703345,901d637c-8add-11eb-8e3f-b4055d3355a6:1-3726883406,b46b8251-5254-11ed-a648-d0946637df48:1-1069556331,db449f07-c53e-11e8-b8c2-d094663d3d1d:1-3543229125,e8d62f95-c77a-11e8-9270-d0946637df48:1-5715021533
```